### PR TITLE
Renaming 'pstr' to 'str' in user type declaration

### DIFF
--- a/src/Famix-Esope-Transformator/FASTFortranBehavioralTransformationVisitor.class.st
+++ b/src/Famix-Esope-Transformator/FASTFortranBehavioralTransformationVisitor.class.st
@@ -265,11 +265,16 @@ FASTFortranBehavioralTransformationVisitor >> visitFASTEsopePointerDeclarationSt
 { #category : 'visiting - esope' }
 FASTFortranBehavioralTransformationVisitor >> visitFASTEsopePointerDeclarator: aFASTEsopePointerDeclarator [ 
 	
-	| esopeDeclarator |
+	| esopeDeclarator pointedTypeName |
+
+	pointedTypeName := (aFASTEsopePointerDeclarator pointedTypeName isNotNil 
+		and: [ aFASTEsopePointerDeclarator pointedTypeName asLowercase = 'pstr' ])
+			ifTrue: [ 'str' ]
+			ifFalse: [ aFASTEsopePointerDeclarator pointedTypeName ].
 
 	esopeDeclarator := self model2k newVariableDeclarationStatement
 		declaredType: (self model2k newUserDefinedType  
-			name: aFASTEsopePointerDeclarator pointedTypeName;
+			name: pointedTypeName;
 			yourself
 		) ;
 		addDeclarator: (aFASTEsopePointerDeclarator variableDeclarator accept: self) ;


### PR DESCRIPTION
`type(pstr)...` become `type(str)...`